### PR TITLE
Feature/add admin users page

### DIFF
--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -1,4 +1,4 @@
-const { User, Tweet } = require('../models')
+const { User, Tweet, Like } = require('../models')
 
 const adminController = {
   signInPage: (req, res) => {
@@ -30,6 +30,32 @@ const adminController = {
       .then(tweets => {
         if (!tweets) throw new Error('Tweets do not exist!')
         res.render('admin/tweets', { tweets, tweetRoute })
+      })
+      .catch(err => next(err))
+  },
+  getUsers: (req, res, next) => {
+    const userRoute = true
+    return User.findAll({
+      attributes: [
+        'id', 'account', 'name', 'email', 'avatar', 'cover'
+      ],
+      include: [
+        { model: Tweet },
+        { model: Like, as: 'LikedTweets' },
+        { model: User, as: 'Followings' },
+        { model: User, as: 'Followers' }
+      ]
+    })
+      .then(users => {
+        users = users.map(user => ({
+          ...user.dataValues,
+          tweetsCount: user.Tweets.length,
+          likesCount: user.LikedTweets.length,
+          followingsCount: user.Followings.length,
+          followersCount: user.Followers.length
+        }))
+        users = users.sort((a, b) => b.tweetsCount - a.tweetsCount)
+        res.render('admin/users', { users, userRoute })
       })
       .catch(err => next(err))
   }

--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -44,10 +44,7 @@ const adminController = {
         { model: Like, as: 'LikedTweets' },
         { model: User, as: 'Followings' },
         { model: User, as: 'Followers' }
-      ],
-      where: {
-        role: 'user'
-      }
+      ]
     })
       .then(users => {
         users = users.map(user => ({

--- a/controllers/admin-controller.js
+++ b/controllers/admin-controller.js
@@ -37,14 +37,17 @@ const adminController = {
     const userRoute = true
     return User.findAll({
       attributes: [
-        'id', 'account', 'name', 'email', 'avatar', 'cover'
+        'id', 'account', 'name', 'email', 'avatar', 'cover', 'role'
       ],
       include: [
         { model: Tweet },
         { model: Like, as: 'LikedTweets' },
         { model: User, as: 'Followings' },
         { model: User, as: 'Followers' }
-      ]
+      ],
+      where: {
+        role: 'user'
+      }
     })
       .then(users => {
         users = users.map(user => ({
@@ -54,6 +57,7 @@ const adminController = {
           followingsCount: user.Followings.length,
           followersCount: user.Followers.length
         }))
+        console.log(users)
         users = users.sort((a, b) => b.tweetsCount - a.tweetsCount)
         res.render('admin/users', { users, userRoute })
       })

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,17 +1,19 @@
 const helpers = require('../_helpers')
 const authenticated = (req, res, next) => {
   if (helpers.ensureAuthenticated(req)) {
-    return next()
+    if (helpers.getUser(req).role === 'user') return next()
+    req.flash('error_messages', '此帳號為管理者帳號，不得登入前台')
+    return res.redirect('/admin/tweets')
   }
   res.redirect('/signin')
 }
 const authenticatedAdmin = (req, res, next) => {
   if (helpers.ensureAuthenticated(req)) {
     if (helpers.getUser(req).role === 'admin') return next()
-    res.redirect('/tweets')
-  } else {
-    res.redirect('/signin')
+    req.flash('error_messages', '此帳號為使用者帳號，不得登入後台')
+    return res.redirect('/tweets')
   }
+  return res.redirect('/signin')
 }
 
 module.exports = {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -8,10 +8,10 @@ body {
 }
  
 button {
-   margin: 0;
-   padding: 0;
-   border: none;
-   outline: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
 }
 
 textarea {
@@ -87,6 +87,26 @@ textarea {
   gap: 8px;
 }
 
+.main-middle {
+  position: absolute;
+  left: 333px;
+  height: 1200px;
+}
+
+.row-card {
+  position: absolute;
+  left: 332px;
+  top: 1px;
+}
+
+.main-user-card {
+  width: 888px;
+  height: 314px;
+  top: 91px;
+  left: 349px;
+  gap: 16px;
+}
+
 .button-container {
   width: 178px;
   height: 58px;
@@ -137,12 +157,6 @@ textarea {
   line-height: 30px;
   letter-spacing: 0px;
   text-align: center;
-}
-
-.main-middle {
-  position: absolute;
-  left: 333px;
-  height: 1200px;
 }
 
 #add-tweet-button {

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,8 +9,8 @@ const { generalErrorHandler } = require('../middleware/error-handler')
 
 router.use('/admin', admin)
 
-router.get('/users/:id/edit', userController.editUser)
-router.get('/users/:id/tweets', userController.getUserTweets)
+router.get('/users/:id/edit', authenticated, userController.editUser)
+router.get('/users/:id/tweets', authenticated, userController.getUserTweets)
 
 // authenticated還沒載入 還沒寫這功能
 // router.post('/followships/:userId', authenticated, userController.addFollowing)

--- a/routes/modules/admin.js
+++ b/routes/modules/admin.js
@@ -10,6 +10,7 @@ router.post('/signin', passport.authenticate('local', { failureRedirect: '/admin
 router.get('/logout', adminController.logOut)
 
 router.get('/tweets', authenticatedAdmin, adminController.getTweets)
+router.get('/users', authenticatedAdmin, adminController.getUsers)
 router.use('/', (req, res) => { res.redirect('/admin/signin') })
 
 module.exports = router

--- a/views/admin/tweets.hbs
+++ b/views/admin/tweets.hbs
@@ -1,7 +1,7 @@
 {{!-- handlebars 頁面還要再修 --}}
 {{> admin-left-sidebar route="getTweets"}}
 <div class="main-middle" id="admin-tweets-page-container">
-  <div class="col-9  border border-top-0 mt-0">
+  <div class="col-9 border border-top-0 mt-0">
     <div class="card-header p-4">
       <h4 class="m-0">推文清單</h4>
     </div>

--- a/views/admin/tweets.hbs
+++ b/views/admin/tweets.hbs
@@ -10,21 +10,19 @@
       <div class="card-body col-12 p-3">
         <div class="row mb-2 p-1">
           <div class="col-1 d-flex justify-content-center align-items-start">
-            <a href="/users/{{this.UserId}}">
-              <img src="{{#if this.User.avatar}}{{ this.User.avatar }}{{else}}https://i.imgur.com/7sJckYK.png{{/if}}"
-                class="rounded-circle" style="width: 50px; height: 50px" alt="avatar">
-            </a>
+            <img src="{{#if this.User.avatar}}{{ this.User.avatar }}{{else}}https://i.imgur.com/7sJckYK.png{{/if}}"
+              class="rounded-circle" style="width: 50px; height: 50px" alt="avatar">
           </div>
           <div class="col-10 row">
             <div class="col-12 d-inline-flex align-items-center">
               <div style="height: 26px; font-size: 15px">
-                <a href="/users/{{ this.UserId }}" class="text-dark" style="font-size: 16px; font-weight: 700; margin-right: 8px; text-decoration: none;">{{ this.User.name }}</a>
+                <span class="text-dark" style="font-size: 16px; font-weight: 700; margin-right: 8px; text-decoration: none;">{{ this.User.name }}</span>
                 <span style="font-size: 14px; font-weight: 400">
                   @{{ this.User.account }}·{{ relativeTime this.User.createdAt }}
                 </span>
               </div>
             </div>
-            <div class="col-12 mt-1" onclick="javascript:location.href='/tweets/{{this.id}}'" style="cursor: pointer;">
+            <div class="col-12 mt-1">
               {{ this.description }}
             </div>
           </div>

--- a/views/admin/users.hbs
+++ b/views/admin/users.hbs
@@ -1,14 +1,51 @@
 {{> admin-left-sidebar route="getUsers"}}
-<div class="main-middle border-start border-end" id="tweets-page-container">
-  <h1>使用者列表</h1>
-  {{#each users}}
-  <p>User cover: {{this.cover}}</p>
-  <p>User avatar: {{this.avatar}}</p>
-  <p>User name: {{this.name}}</p>
-  <p>User account: {{this.account}}</p>
-  <p>Tweet count: {{this.tweetsCount}}</p>
-  <p>Like count: {{this.likesCount}}</p>
-  <p>Followings: {{this.followingsCount}}</p>
-  <p>Followers: {{this.followersCount}}</p>
-  {{/each}}
+<div class="admin-user-middle" id="admin-user-page-container">
+  <div class="col-9 mt-3 row-card">
+    <div class="card-header user-page-title px-4" style="font-size: 24px; font-weight: 700;">
+      使用者列表
+    </div>
+    <div class="d-flex flex-row main-user-card p-3">
+      <div class="row row-item">
+      {{#each users}}
+        <div class="d-flex flex-column col-3">
+          <div class="card my-3 rounded-4" style="border: none;">
+            <div class="user-info">
+              <img src="{{#if this.cover}}{{this.cover}}{{else}}https://i.imgur.com/f42NkFh.png{{/if}}"
+                class="position-absolute rounded-3" style="width: 100%; height: 45%; z-index:0;" alt="background">
+              <img src="{{#if this.avatar}}{{this.avatar}}{{else}}/images/no-avatar.png{{/if}}"
+                class="position-absolute rounded-circle mt-4"
+                style="width: 85px; height: 85px; left: 29%; top: 50px; border: white 4px solid; z-index: 1" alt="avatar">
+            </div>
+            <div class="card-body bg-light" style="padding-top: 88%;">
+              <div class="card-title text-center mb-3" style="color: #000000; font-size: 16px; font-weight: 700; height: 8px;">
+                {{this.name}}</div>
+              <div class="card-title text-center" style="color: #6c757d; font-size: 14px; font-weight: 400">
+                @{{this.account}}
+              </div>
+              <div class="text-center mb-2 text-dark d-flex justify-content-center">
+                <div class="tweet-count me-3">
+                  <img src="/images/icons/tweets.png" alt="tweetsCount">
+                  <span>{{this.tweetsCount}}</span>
+                </div>
+                <div class="tweets-like">
+                  <img src="/images/icons/like.png" alt="tweetsLikeCount">
+                  <span>{{this.likesCount}}</span>
+                </div>
+              </div>
+            
+              <div class="text-center mt-2 d-flex justify-content-center">
+                <div class="followings-count me-2">
+                  <span>{{this.followingsCount}}個<span style="color: #6c757d;">跟隨中</span></span>
+                </div>
+                <div class="followers-count">
+                  <span>{{this.followersCount}}位<span style="color: #6c757d;">跟隨者</span></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
 </div>

--- a/views/admin/users.hbs
+++ b/views/admin/users.hbs
@@ -1,0 +1,14 @@
+{{> admin-left-sidebar route="getUsers"}}
+<div class="main-middle border-start border-end" id="tweets-page-container">
+  <h1>使用者列表</h1>
+  {{#each users}}
+  <p>User cover: {{this.cover}}</p>
+  <p>User avatar: {{this.avatar}}</p>
+  <p>User name: {{this.name}}</p>
+  <p>User account: {{this.account}}</p>
+  <p>Tweet count: {{this.tweetsCount}}</p>
+  <p>Like count: {{this.likesCount}}</p>
+  <p>Followings: {{this.followingsCount}}</p>
+  <p>Followers: {{this.followersCount}}</p>
+  {{/each}}
+</div>

--- a/views/partials/admin-left-sidebar.hbs
+++ b/views/partials/admin-left-sidebar.hbs
@@ -21,12 +21,21 @@
         </span>
       </a>
       {{/if}}
+      {{#if userRoute}}
+      <a href="/admin/users" class="nav-link button-container" id="profile">
+        <span class="icon-description p-0" id="profile-span" style="color: #FF4400">
+          <img src="/images/icons/orange-profile.png" alt="profile" id="profile-icon" class="sidebar-icon">
+          使用者列表
+        </span>
+      </a>
+      {{else}}
       <a href="/admin/users" class="nav-link button-container" id="profile">
         <span class="icon-description p-0" id="profile-span">
           <img src="/images/icons/profile.png" alt="profile" id="profile-icon" class="sidebar-icon">
           使用者列表
         </span>
       </a>
+      {{/if}}
     </nav>
   </div>
   <div id="logout">


### PR DESCRIPTION
管理者可以瀏覽站內所有的使用者清單 

使用者社群活躍數據，包括
背景、頭像、姓名、帳號。
推文數量（指使用者的 Tweet 累積總量）
推文被 like 的數量（指使用者的 Tweet 獲得 like 的累積總量）
跟隨中人數
跟隨者人數
使用者清單預設按推文數排序，由多至少

路由：GET /admin/users